### PR TITLE
introduce stop_failed_gnfs option

### DIFF
--- a/aliqueit.ini
+++ b/aliqueit.ini
@@ -25,11 +25,11 @@ makedir_cmd = mkdir
 //----------------------------------
 //Executables
 //
-//Note that you'll want to specify the full path and filename to the 
-//executables unless they're in a directory included in your PATH environment 
-//variable. This is especially true of msieve_cmd if you're going to use msieve 
-//for poly finding. Just putting msieve in your aliqueit dir is not enough 
-//because every gnfs run gets its own subdirectory and tries to start 
+//Note that you'll want to specify the full path and filename to the
+//executables unless they're in a directory included in your PATH environment
+//variable. This is especially true of msieve_cmd if you're going to use msieve
+//for poly finding. Just putting msieve in your aliqueit dir is not enough
+//because every gnfs run gets its own subdirectory and tries to start
 //msieve_cmd from there.
 //----------------------------------
 
@@ -66,6 +66,9 @@ use_msieve_polyfind = true
 
 //Stop if sequence merges with an earlier sequence?
 detect_merge = true
+
+//Stop if gnfs poly couldn't be found or gnfs failed, otherwise run autoincreasing ecm until factor found
+stop_failed_gnfs = false
 
 //Trial factor with primes < this value.
 trial_cutoff = 10000
@@ -124,10 +127,10 @@ ecm_tempfile = aliqueit_ecm_temp.log
 //1000 curves ~ B1=2.25e6
 //For <65 digits I've experimentally found these values to be good on my machine. Improvements are always welcome!
 //NOTE: These values are only used for composites < <big_ecm_cutoff> digits. See that setting below.
-ecm_depth = 45 10, 50 15, 55 20, 60 30, 65 40, 70 60, 73 90, 76 120, 79 150, 82 180, 83 200, 86 300, 90 400, 93 500, 96 600, 99 700, 102 800, 106 900, 110 1000, 114 1100, 118 1200, 122 1300 
+ecm_depth = 45 10, 50 15, 55 20, 60 30, 65 40, 70 60, 73 90, 76 120, 79 150, 82 180, 83 200, 86 300, 90 400, 93 500, 96 600, 99 700, 102 800, 106 900, 110 1000, 114 1100, 118 1200, 122 1300
 
 //If composite has more than <big_ecm_cutoff> digits, we will try to do ecm for about 1/4 of the estimated time qs/nfs would take.
-//I've used logs of previous factorisations on my machine to construct the estimates that are used. They have been converted to 
+//I've used logs of previous factorisations on my machine to construct the estimates that are used. They have been converted to
 //linear formulas taking the composite size as input and giving maximum factor size (see Table 1 in gmp-ecm readme) as output.
 //See also qs_k, qs_m, gnfs_k, and gnfs_m below.
 big_ecm_cutoff = 65
@@ -141,8 +144,8 @@ qs_m = -11.26
 gnfs_k = 0.235
 gnfs_m = 9.4
 
-//Multiply default B1 and B2 values by these constants for ECM. b2scale is 
-//passed to gmp-ecm with the -B2scale argument and doesn't correspond exactly 
+//Multiply default B1 and B2 values by these constants for ECM. b2scale is
+//passed to gmp-ecm with the -B2scale argument and doesn't correspond exactly
 //to a B2 multiplication by this value.
 b1scale_ecm = 1.0
 b2scale_ecm = 1.0
@@ -152,14 +155,14 @@ b2scale_ecm = 1.0
 //----------------------------------
 //P-1/P+1 tuning
 //----------------------------------
-//Multiply default B1 and B2 values by these constants for P-1. b2scale is 
-//passed to gmp-ecm with the -B2scale argument and doesn't correspond exactly 
+//Multiply default B1 and B2 values by these constants for P-1. b2scale is
+//passed to gmp-ecm with the -B2scale argument and doesn't correspond exactly
 //to a B2 multiplication by this value.
 b1scale_pm1 = 1.0
 b2scale_pm1 = 1.0
 
-//Multiply default B1 and B2 values by these constants for P+1. b2scale is 
-//passed to gmp-ecm with the -B2scale argument and doesn't correspond exactly 
+//Multiply default B1 and B2 values by these constants for P+1. b2scale is
+//passed to gmp-ecm with the -B2scale argument and doesn't correspond exactly
 //to a B2 multiplication by this value.
 b1scale_pp1 = 1.0
 b2scale_pp1 = 1.0

--- a/src/aliqueit/aliqueit.cc
+++ b/src/aliqueit/aliqueit.cc
@@ -655,12 +655,16 @@ bool factor( mpz_class n, vector<pair<mpz_class,int> > & factors, vector<mpz_cla
 						<< "I'll cheerfully loop and try again though..." << endl;
 				}
 			} else {	//bring out the big gnfs guns then
-				if( !run_gnfs( input, new_factors ) ) {
-					cout << "WARNING: gnfs failed to find a factor. This really shouldn't happen." << endl
-						<< "I'll just run ecm till the end of time or a factor turns up..." << endl
-						<< "Let's hope you don't run out of disk space before either of those." << endl;
-					run_ecm_autoinc( input, new_factors, true );
-				}
+				if (cfg.stop_failed_gnfs) {
+                        cout << "WARNING: gnfs failed to find a factor. This really shouldn't happen." << endl
+                            << "I'll just run ecm till the end of time or a factor turns up..." << endl
+                            << "Let's hope you don't run out of disk space before either of those." << endl;
+                        run_ecm_autoinc( input, new_factors, true );
+                    } else {
+                        cout << "WARNING: gnfs failed to find a factor. This really shouldn't happen." << endl;
+                        log_msg( "*** gnfs failed to find a factor. Ending.\n" );
+                        return false;
+                    }
 			}
 			add_factors( n, factors, new_factors );
 		}

--- a/src/aliqueit/aliqueit.cc
+++ b/src/aliqueit/aliqueit.cc
@@ -655,7 +655,8 @@ bool factor( mpz_class n, vector<pair<mpz_class,int> > & factors, vector<mpz_cla
 						<< "I'll cheerfully loop and try again though..." << endl;
 				}
 			} else {	//bring out the big gnfs guns then
-				if (cfg.stop_failed_gnfs) {
+                if (!run_gnfs( input, new_factors )) {
+                    if (cfg.stop_failed_gnfs) {
                         cout << "WARNING: gnfs failed to find a factor. This really shouldn't happen." << endl
                             << "I'll just run ecm till the end of time or a factor turns up..." << endl
                             << "Let's hope you don't run out of disk space before either of those." << endl;
@@ -665,6 +666,7 @@ bool factor( mpz_class n, vector<pair<mpz_class,int> > & factors, vector<mpz_cla
                         log_msg( "*** gnfs failed to find a factor. Ending.\n" );
                         return false;
                     }
+                }
 			}
 			add_factors( n, factors, new_factors );
 		}

--- a/src/aliqueit/cfg.cc
+++ b/src/aliqueit/cfg.cc
@@ -17,6 +17,9 @@ cfg_t::cfg_t() {
 	//Stop if sequence merges with an earlier sequence?
 	detect_merge = true;
 
+    //Stop if gnfs poly couldn't be found or gnfs failed, otherwise run autoincreasing ecm until factor found
+    stop_failed_gnfs = false;
+
 	//Trial factor with primes < this value.
 	trial_cutoff = 10000;
 
@@ -96,12 +99,12 @@ cfg_t::cfg_t() {
 	//1000 curves ~ B1=2.25e6
 	//For <65 digits I've experimentally found these values to be good on my machine. Improvements are always welcome!
 	//NOTE: These values are only used for composites < <big_ecm_cutoff> digits. See that setting below.
-	ecm_depth = 
+	ecm_depth =
 		"45 10, 50 15, 55 20, 60 30, 65 40, 70 60, 73 90, 76 120, 79 150, 82 180, "
 		"83 200, 86 300, 90 400, 93 500, 96 600, 99 700, 102 800, 106 900, 110 1000, 114 1100, 118 1200, 122 1300, ";
 
 	//If composite has more than <big_ecm_cutoff> digits, we will try to do ecm for about 1/4 of the estimated time qs/nfs would take.
-	//I've used logs of previous factorisations on my machine to construct the estimates that are used. They have been converted to 
+	//I've used logs of previous factorisations on my machine to construct the estimates that are used. They have been converted to
 	//linear formulas taking the composite size as input and giving maximum factor size (see Table 1 in gmp-ecm readme) as output.
 	//See also qs_k, qs_m, gnfs_k, and gnfs_m below.
 	big_ecm_cutoff = 65;
@@ -181,7 +184,7 @@ void cfg_t::read_config_file() {
 		string arg = tolower( trim( line.substr( 0, o ) ) );	//arg name
 		string val = trim( line.substr( o + 1 ) );		//value
 		//cout << arg << " = " << val << endl;
-		
+
 		//assign values...
 		if( arg == "trial_cutoff" ) {
 			trial_cutoff = get_uint( val );
@@ -219,6 +222,8 @@ void cfg_t::read_config_file() {
 			null_device = val;
 		} else if( arg == "detect_merge" ) {
 			detect_merge = get_bool( val );
+        } else if( arg == "stop_failed_gnfs" ) {
+			stop_failed_gnfs = get_bool( val );
 		} else if( arg == "big_ecm_cutoff" ) {
 			big_ecm_cutoff = get_uint( val );
 		} else if( arg == "neat_factor_limit_ecm" ) {

--- a/src/aliqueit/cfg.h
+++ b/src/aliqueit/cfg.h
@@ -9,6 +9,7 @@ class cfg_t {
 public:
 	bool use_msieve_polyfind;
 	bool detect_merge;
+    bool stop_failed_gnfs;
 	unsigned int trial_cutoff;
 	unsigned int gnfs_cutoff;
 	bool prefer_yafu;

--- a/src/aliqueit/nbproject/configurations.xml
+++ b/src/aliqueit/nbproject/configurations.xml
@@ -38,7 +38,7 @@
           <executablePath>aliqueit</executablePath>
           <ccTool>
             <incDir>
-              <pElem>../gmp</pElem>
+              <pElem>../../../../gmp</pElem>
             </incDir>
           </ccTool>
         </makeTool>
@@ -53,12 +53,6 @@
       </item>
       <item path="misc.cc" ex="false" tool="1" flavor2="4">
         <ccTool flags="0">
-          <incDir>
-            <pElem>../../../../gmp</pElem>
-          </incDir>
-          <incFile>
-            <pElem>/usr/local/lib</pElem>
-          </incFile>
         </ccTool>
       </item>
     </conf>

--- a/src/aliqueit/nbproject/configurations.xml
+++ b/src/aliqueit/nbproject/configurations.xml
@@ -51,18 +51,14 @@
         <ccTool flags="0">
         </ccTool>
       </item>
-      <folder path="0">
-        <ccTool>
+      <item path="misc.cc" ex="false" tool="1" flavor2="4">
+        <ccTool flags="0">
           <incDir>
             <pElem>../../../../gmp</pElem>
           </incDir>
           <incFile>
             <pElem>/usr/local/lib</pElem>
           </incFile>
-        </ccTool>
-      </folder>
-      <item path="misc.cc" ex="false" tool="1" flavor2="0">
-        <ccTool flags="0">
         </ccTool>
       </item>
     </conf>


### PR DESCRIPTION
- this will stop aliqueit with a message if gnfs couldn't find a poly or failed in some other way
- the default is the current behaviour to run autoincreasing ecm (which is not what I want)
